### PR TITLE
URL折り返し対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,6 +343,7 @@ h2 {
 	padding: 1em;
 	margin: 1em;
 	line-height: 1.8em;
+	word-break: break-all;
 }
 .url {
 	background-color: #ABCFEF;


### PR DESCRIPTION
item内に長いURLが存在する場合、スマートホンで表示したときに、URLが折り返されず表示され、レイアウトが崩れているので、URLを折り返すよう、CSSを修正しました。
