### PR TITLE
文中のURLにハイパーリンク

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@ const shuffle = function(array) {
 const setHyperLink = function(str) {
 	var reg = /((h?)(ttps?:\/\/[a-zA-Z0-9.\-_@:/~?%&;=+#',()*!]+))/g; // ']))/;
     var regexpMakeLink = function(all, url, h, href) {
-        return '<a href="h' + href + '">' + url + '</a>';
+        return '<span class="url_string"><a href="h' + href + '">' + url + '</a></span>';
     }
     return str.replace(reg, regexpMakeLink);
 }
@@ -351,6 +351,8 @@ h2 {
 	padding: 1em;
 	margin: 1em;
 	line-height: 1.8em;
+}
+.url_string {
 	word-break: break-all;
 }
 .url {

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@ URL: "https://www.shikumi.co.jp/springin-fes-2020-spring/"
 有無: "有"
 */
 // <ruby>${d['http://xmlns.com/foaf/0.1/#name']}<rt>${d['name_yomi']}</rt></ruby>
-			div.innerHTML = `
+			div.innerHTML = setHyperLink(`
 				<h2>${d['サービス名称']}</h2>
 				<div class=description>${d['詳細']}</div>
 				<div class=from>提供: ${d['企業等']}</div>
@@ -113,10 +113,9 @@ URL: "https://www.shikumi.co.jp/springin-fes-2020-spring/"
 				<div class=service>${d['サービス分類']}</div>
 				<div class=keyword>${d['キーワード']}</div>
 				<div class=target>${d['対象者']}</div>
-				</div>
+				</div>`) + 
+				`<div class=url><a href="${d['URL']}">アクセスしてみる</a></div>`;
 
-				<div class=url><a href=${d['URL']}>アクセスしてみる</a></div>
-			`
 			const SET = { '.type': '分野', '.service': 'サービス分類', '.keyword': 'キーワード', '.target': "対象者" }
 			for (const s in SET) {
 				const sname = SET[s]
@@ -271,6 +270,15 @@ const shuffle = function(array) {
 		array[n] = tmp
 	}
 }
+
+const setHyperLink = function(str) {
+	var reg = /((h?)(ttps?:\/\/[a-zA-Z0-9.\-_@:/~?%&;=+#',()*!]+))/g; // ']))/;
+    var regexpMakeLink = function(all, url, h, href) {
+        return '<a href="h' + href + '">' + url + '</a>';
+    }
+    return str.replace(reg, regexpMakeLink);
+}
+
 </script>
 <style>
 body {


### PR DESCRIPTION
文中にURLがあった場合、Aタグを挿入し、ハイパーリンクを設定するよう修正しました。

前回の修正で、URLの文字列が折り返すよう、itemに word-break: break-all  を追加しましたが、このスタイルのせいで、禁則処理が無効になり、句読点が行頭に来るようになってしまいました。

そのため、今回の処理で挿入するAタグを以下のようにしました。
```
<span class="url_string"><a href="https://example.com">https://example.com</a></span>
```

そして、url_stringクラスにword-break: break-all を設定することで、禁則処理も働き、URLは折り返され、ハイパーリンクも有効になります。
